### PR TITLE
Abstract feed handling into consumer.go

### DIFF
--- a/consumer/composererrors.go
+++ b/consumer/composererrors.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	apibsky "github.com/bluesky-social/indigo/api/bsky"
-	"github.com/bluesky-social/jetstream/pkg/models"
 	dbpkg "jetstream-feed-generator/db/sqlc"
 	"log/slog"
 	"regexp"
 	"strings"
+
+	apibsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/jetstream/pkg/models"
 )
 
 type ComposerErrorsFeed struct {
@@ -31,33 +32,8 @@ func (f *ComposerErrorsFeed) Name() string {
 	return f.name
 }
 
-func (f *ComposerErrorsFeed) Initialize(ctx context.Context) error {
-	if err := f.q.UpsertFeed(ctx, f.Name()); err != nil {
-		return fmt.Errorf("failed to upsert feed: %v", err)
-	}
-	return nil
-}
-
-func (f *ComposerErrorsFeed) LatestCursor(ctx context.Context) (int64, error) {
-	feed, err := f.q.GetFeed(ctx, f.Name())
-	if err != nil {
-		return 0, err
-	}
-	if feed.LatestCursor.Valid {
-		return feed.LatestCursor.Int64, nil
-	}
-	return 0, nil
-}
-
-func (f *ComposerErrorsFeed) SaveCursor(ctx context.Context, cursor int64) error {
-	err := f.q.UpdateFeedCursor(ctx, dbpkg.UpdateFeedCursorParams{
-		LatestCursor: sql.NullInt64{Int64: cursor, Valid: true},
-		FeedName:     f.Name(),
-	})
-	if err != nil {
-		return err
-	}
-	return nil
+func (f *ComposerErrorsFeed) DB() *dbpkg.Queries {
+	return f.q
 }
 
 func (f *ComposerErrorsFeed) HandlePost(ctx context.Context, event *models.Event, post *apibsky.FeedPost) error {

--- a/consumer/english.go
+++ b/consumer/english.go
@@ -2,11 +2,14 @@ package consumer
 
 import (
 	"context"
-	apibsky "github.com/bluesky-social/indigo/api/bsky"
-	"github.com/bluesky-social/jetstream/pkg/models"
+	"database/sql"
+	dbpkg "jetstream-feed-generator/db/sqlc"
 	"log/slog"
 	"slices"
 	"unicode"
+
+	apibsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/jetstream/pkg/models"
 )
 
 // EmojiRange represents a Unicode range for emoji characters
@@ -46,27 +49,20 @@ func ContainsEmoji(s string) bool {
 type EnglishTextFeed struct {
 	name   string
 	logger *slog.Logger
+	q      *dbpkg.Queries
 }
 
-func (f *EnglishTextFeed) Initialize(ctx context.Context) error {
-	return nil
-}
-
-func (f *EnglishTextFeed) LatestCursor(ctx context.Context) (int64, error) {
-	return 0, nil
-}
-
-func (f *EnglishTextFeed) SaveCursor(ctx context.Context, cursor int64) error {
-	return nil
-}
-
-func NewEnglishTextFeed(name string, logger *slog.Logger) *EnglishTextFeed {
+func NewEnglishTextFeed(name string, logger *slog.Logger, db *sql.DB) *EnglishTextFeed {
 	feedLogger := logger.With("feed", name)
-	return &EnglishTextFeed{name, feedLogger}
+	return &EnglishTextFeed{name, feedLogger, dbpkg.New(db)}
 }
 
 func (f *EnglishTextFeed) Name() string {
 	return f.name
+}
+
+func (f *EnglishTextFeed) DB() *dbpkg.Queries {
+	return f.q
 }
 
 func (f *EnglishTextFeed) HandlePost(ctx context.Context, event *models.Event, post *apibsky.FeedPost) error {


### PR DESCRIPTION
Move the common feed functions relating to database access into `consumer.go` to avoid needing to implement them in each individual feed.